### PR TITLE
Update for JDK 9+ (jaxb), do not use snapshots

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,16 +46,6 @@
     <jclouds.version>2.1.2</jclouds.version>
   </properties>
 
-  <repositories>
-    <repository>
-      <id>apache-snapshots</id>
-      <url>https://repository.apache.org/content/repositories/snapshots</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
   <build>
     <plugins>
       <plugin>
@@ -166,6 +156,16 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
       <version>1.1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.2.11</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+      <version>1.1.1</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Hi Andrew, in order to compile and run it with JDK11 and JDK8 I needed to make these changes.

And btw. it works with an EMC Elastic Cloud Storage with the generic "s3" provider.